### PR TITLE
Feat/#5

### DIFF
--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/ExchangeRateViewController.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/ExchangeRateViewController.swift
@@ -14,6 +14,8 @@ class ExchangeRateViewController: UIViewController {
     // API 결과로 받을 환율 데이터 (정렬 포함)
     private var exchangeRates: [(String, Double)] = []
     
+    private var filteredRates: [(String, Double)] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view = exchangeRateView
@@ -27,6 +29,7 @@ class ExchangeRateViewController: UIViewController {
     private func setupTableView() {
         exchangeRateView.tableView.dataSource = self
         exchangeRateView.tableView.delegate = self
+        exchangeRateView.searchBar.delegate = self
     }
     
     // API 호출
@@ -72,4 +75,19 @@ extension ExchangeRateViewController: UITableViewDataSource, UITableViewDelegate
     }
 }
 
-
+extension ExchangeRateViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        guard !searchText.isEmpty else {
+            filteredRates = exchangeRates
+            exchangeRateView.tableView.reloadData()
+            return
+        }
+        
+        filteredRates = exchangeRates.filter { (code, _) in
+            let country = ExchangeRateMapper.countryName(for: code)
+            return code.lowercased().contains(searchText.lowercased()) ||
+                   country.lowercased().contains(searchText.lowercased())
+        }
+        exchangeRateView.tableView.reloadData()
+    }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateView.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateView.swift
@@ -14,7 +14,7 @@ class ExchangeRateView: UIView {
     // 뷰에 들어갈 컴포넌트들을 정의하는 공간
     let searchBar: UISearchBar = {
         let searchBar = UISearchBar()
-        searchBar.text = "통화 검색"
+        searchBar.placeholder = "통화 검색"
         searchBar.backgroundImage = UIImage()
         
         return searchBar


### PR DESCRIPTION
# ✨ 기능 추가 PR

## 📌 관련 이슈
- close #5 

## 📌 변경 사항 및 이유
- 사용자가 통화 코드 또는 국가명을 기준으로 검색할 수 있는 필터링 기능을 구현했습니다.
- `UISearchBar` 입력 시 실시간으로 `filteredRates`에 반영되며, 테이블 뷰가 즉시 갱신됩니다.
- 필터링 기준은 통화 코드와 국가명 모두 포함됩니다.

## 📌 PR Point
- 검색어가 통화 코드 또는 국가명에 포함되면 해당 셀만 필터링되어 표시됩니다.
- 검색어가 비어있을 경우 전체 리스트가 복구됩니다.
- 검색 결과가 없을 경우 "검색 결과 없음" 셀을 중앙 정렬로 안내합니다.
- `ExchangeRateMapper`를 사용해 통화 코드에 맞는 국가명을 매핑합니다.

## 📌 참고 사항
- 테이블 뷰 렌더링 기준을 `exchangeRates` → `filteredRates`로 전환하였습니다.