### PR TITLE
Feat/#17

### DIFF
--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/CoreDataManager.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/CoreDataManager.swift
@@ -1,0 +1,53 @@
+//
+//  CoreDataManager.swift
+//  YWSCurrencyCalculator
+//
+//  Created by 양원식 on 4/22/25.
+//
+
+import Foundation
+import CoreData
+
+final class CoreDataManager {
+    static let shared = CoreDataManager()
+
+    private let container: NSPersistentContainer
+
+    private init() {
+        container = NSPersistentContainer(name: "FavoriteModel")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Core Data 로딩 실패: \(error)")
+            }
+        }
+    }
+
+    var context: NSManagedObjectContext { container.viewContext }
+
+    func saveFavorite(code: String) {
+        let favorite = FavoriteCurrency(context: context)
+        favorite.code = code
+        try? context.save()
+    }
+
+    func removeFavorite(code: String) {
+        let request = FavoriteCurrency.fetchRequest()
+        request.predicate = NSPredicate(format: "code == %@", code)
+        if let result = try? context.fetch(request), let first = result.first {
+            context.delete(first)
+            try? context.save()
+        }
+    }
+
+    func getAllFavorites() -> [String] {
+        let request = FavoriteCurrency.fetchRequest()
+        let result = try? context.fetch(request)
+        return result?.compactMap { $0.code } ?? []
+    }
+
+    func isFavorite(code: String) -> Bool {
+        let request = FavoriteCurrency.fetchRequest()
+        request.predicate = NSPredicate(format: "code == %@", code)
+        return (try? context.count(for: request)) ?? 0 > 0
+    }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/FavoriteCurrency.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/FavoriteCurrency.swift
@@ -1,0 +1,20 @@
+//
+//  FavoriteCurrency.swift
+//  YWSCurrencyCalculator
+//
+//  Created by 양원식 on 4/22/25.
+//
+
+import Foundation
+import CoreData
+
+@objc(FavoriteCurrency)
+public class FavoriteCurrency: NSManagedObject {
+    @NSManaged public var code: String
+}
+
+extension FavoriteCurrency {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<FavoriteCurrency> {
+        return NSFetchRequest<FavoriteCurrency>(entityName: "FavoriteCurrency")
+    }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/FavoriteModel.xcdatamodeld/FavoriteModel.xcdatamodel/contents
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/FavoriteModel.xcdatamodeld/FavoriteModel.xcdatamodel/contents
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="FavoriteCurrency" representedClassName=".FavoriteCurrency" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
@@ -47,6 +47,13 @@ class ExchangeRateCell: UITableViewCell {
         return label
     }()
     
+    private let favoriteButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "star"), for: .normal)
+        button.tintColor = .systemYellow
+        return button
+    }()
+    
     // MARK: - Initializers
     
     /// 셀 초기화 메서드입니다. SnapKit을 활용해 오토레이아웃을 설정합니다.
@@ -56,6 +63,7 @@ class ExchangeRateCell: UITableViewCell {
         
         contentView.addSubview(labelStackView)
         contentView.addSubview(rateLabel)
+        contentView.addSubview(favoriteButton)
         
         labelStackView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(16)
@@ -63,10 +71,14 @@ class ExchangeRateCell: UITableViewCell {
         }
         
         rateLabel.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(16)
             make.centerY.equalToSuperview()
             make.leading.equalTo(labelStackView.snp.trailing).offset(16)
-            make.width.equalTo(120)
+        }
+        
+        favoriteButton.snp.makeConstraints { make in
+            make.leading.equalTo(rateLabel.snp.trailing).offset(16)
+            make.trailing.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
         }
     }
     

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
@@ -8,9 +8,16 @@
 import UIKit
 import SnapKit
 
+protocol ExchangeRateCellDelegate: AnyObject {
+    func ExchangeRateCellDidTapFavorite()
+}
+
 /// 환율 정보를 보여주는 커스텀 셀입니다.
 /// 통화 코드, 국가명, 환율 값을 수직/수평으로 정렬하여 표시합니다.
 class ExchangeRateCell: UITableViewCell {
+    
+    private var isFavorite: Bool = false
+    weak var delegate: ExchangeRateCellDelegate?
     
     // MARK: - UI Components
     
@@ -59,6 +66,7 @@ class ExchangeRateCell: UITableViewCell {
     /// 셀 초기화 메서드입니다. SnapKit을 활용해 오토레이아웃을 설정합니다.
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupActions()
         selectionStyle = .none
         
         contentView.addSubview(labelStackView)
@@ -97,5 +105,34 @@ class ExchangeRateCell: UITableViewCell {
         currencyLabel.text = currency
         countryLabel.text = ExchangeRateMapper.countryName(for: currency)
         rateLabel.text = String(format: "%.4f", rate)
+
+        isFavorite = CoreDataManager.shared.isFavorite(code: currency)
+        updateFavoriteImage()
     }
+    
+    private func setupActions() {
+        favoriteButton.addTarget(self, action: #selector(didTapFavorite), for: .touchUpInside)
+    }
+
+
+    private func updateFavoriteImage() {
+        let imageName = isFavorite ? "star.fill" : "star"
+        favoriteButton.setImage(UIImage(systemName: imageName)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        favoriteButton.tintColor = .systemYellow
+    }
+
+    @objc private func didTapFavorite() {
+        guard let code = currencyLabel.text else { return }
+        isFavorite.toggle()
+        updateFavoriteImage()
+
+        if isFavorite {
+            CoreDataManager.shared.saveFavorite(code: code)
+        } else {
+            CoreDataManager.shared.removeFavorite(code: code)
+        }
+
+        delegate?.ExchangeRateCellDidTapFavorite()
+    }
+
 }

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
@@ -74,6 +74,7 @@ extension ExchangeRateViewController: UITableViewDataSource, UITableViewDelegate
 
         let (currency, rate) = filtered[indexPath.row]
         cell.configure(currency: currency, rate: rate)
+        cell.delegate = self
         return cell
     }
 
@@ -86,4 +87,10 @@ extension ExchangeRateViewController: UITableViewDataSource, UITableViewDelegate
         navigationController?.pushViewController(calculatorVC, animated: true)
     }
 }
+extension ExchangeRateViewController: ExchangeRateCellDelegate {
+    func ExchangeRateCellDidTapFavorite() {
+        viewModel.send(action: .fetch)
+    }
+}
+
 


### PR DESCRIPTION
# ✨ 기능 추가 PR

## 📌 관련 이슈
이 PR이 연결된 이슈를 적어주세요. 예:  
- close #17 

## 📌 변경 사항 및 이유
즐겨찾기(⭐️) 기능을 추가해, 즐겨찾은 통화를 리스트 상단에 고정
셀 우측에 ⭐ / ☆ 버튼 추가
이미지 이름 : star.fill / star
클릭 시 해당 통화 코드가 CoreData에 저장/삭제됨
리스트 출력 시 즐겨찾기 데이터를 먼저 상단에 배치
즐겨찾기된 데이터도 알파벳 오름차순 정렬이 되어야 함
즐겨찾기 상태에 따라 ⭐ / ☆ UI를 다르게 표시

