### PR TITLE
Feat/#21

### DIFF
--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/BackgroundColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/BackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/ButtonColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/ButtonColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xCE",
+          "red" : "0x87"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/CellBackgroundColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/CellBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/FavoriteColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/FavoriteColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x96",
+          "green" : "0xFD",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/SecondaryTextColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/SecondaryTextColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0x66"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB3",
+          "green" : "0xB3",
+          "red" : "0xB3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/TextColor.colorset/Contents.json
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Resources/Assets.xcassets/TextColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/CalculatorView.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/CalculatorView.swift
@@ -29,6 +29,7 @@ class CalculatorView: UIView {
     private let currencyLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 24, weight: .bold)
+        label.textColor = UIColor(named: "TextColor") ?? .label
         
         return label
     }()
@@ -37,6 +38,7 @@ class CalculatorView: UIView {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         label.textColor = .gray
+        label.textColor = UIColor(named: "SecondaryTextColor") ?? .secondaryLabel
         
         return label
     }()
@@ -44,6 +46,7 @@ class CalculatorView: UIView {
     let resultLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 20, weight: .medium)
+        label.textColor = UIColor(named: "TextColor") ?? .label
         label.textAlignment = .center
         label.numberOfLines = 0
         
@@ -56,12 +59,14 @@ class CalculatorView: UIView {
         textField.keyboardType = .decimalPad
         textField.textAlignment = .center
         textField.placeholder = "금액을 입력하세요"
+        textField.textColor = UIColor(named: "TextColor") ?? .label
         
         return textField
     }()
     
     private let convertButton: UIButton = {
         let button = UIButton()
+        button.backgroundColor = UIColor(named: "ButtonColor") ?? .systemBlue
         button.backgroundColor = .systemBlue
         button.setTitle("환율 계산", for: .normal)
         button.setTitleColor(.white, for: .normal)
@@ -77,6 +82,7 @@ class CalculatorView: UIView {
     // init(frame:) 또는 required init?(coder:) 구현
     override init(frame: CGRect) {
         super.init(frame: frame)
+        backgroundColor = UIColor(named: "BackgroundColor") ?? .systemBackground
         setupUI()
     }
     

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateCell.swift
@@ -33,7 +33,7 @@ class ExchangeRateCell: UITableViewCell {
     private let currencyLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .medium)
-        label.textColor = .label
+        label.textColor = UIColor(named: "TextColor") ?? .label
         return label
     }()
     
@@ -41,7 +41,7 @@ class ExchangeRateCell: UITableViewCell {
     private let countryLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14)
-        label.textColor = .gray
+        label.textColor = UIColor(named: "SecondaryTextColor") ?? .secondaryLabel
         return label
     }()
     
@@ -50,14 +50,14 @@ class ExchangeRateCell: UITableViewCell {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         label.textAlignment = .right
-        label.textColor = .label
+        label.textColor = UIColor(named: "TextColor") ?? .label
         return label
     }()
     
     private let favoriteButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "star"), for: .normal)
-        button.tintColor = .systemYellow
+        button.tintColor = UIColor(named: "FavoriteColor") ?? .systemYellow
         return button
     }()
     
@@ -74,6 +74,8 @@ class ExchangeRateCell: UITableViewCell {
     /// 셀 초기화 메서드입니다. SnapKit을 활용해 오토레이아웃을 설정합니다.
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.backgroundColor = UIColor(named: "CellBackgroundColor") ?? .systemBackground
+        
         setupActions()
         selectionStyle = .none
         
@@ -151,7 +153,7 @@ class ExchangeRateCell: UITableViewCell {
     private func updateFavoriteImage() {
         let imageName = isFavorite ? "star.fill" : "star"
         favoriteButton.setImage(UIImage(systemName: imageName)?.withRenderingMode(.alwaysTemplate), for: .normal)
-        favoriteButton.tintColor = .systemYellow
+        favoriteButton.tintColor = UIColor(named: "FavoriteColor") ?? .systemYellow
     }
 
     @objc private func didTapFavorite() {

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateView.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/View/ExchangeRateView.swift
@@ -21,6 +21,8 @@ class ExchangeRateView: UIView {
         let searchBar = UISearchBar()
         searchBar.placeholder = "통화 검색"
         searchBar.backgroundImage = UIImage() // 상단 라인 제거
+        searchBar.searchTextField.backgroundColor = UIColor(named: "CellBackgroundColor") ?? .secondarySystemBackground
+        searchBar.searchTextField.textColor = UIColor(named: "TextColor") ?? .label
         return searchBar
     }()
     
@@ -33,6 +35,7 @@ class ExchangeRateView: UIView {
         tableView.separatorStyle = .singleLine
         tableView.rowHeight = 60
         tableView.register(ExchangeRateCell.self, forCellReuseIdentifier: "ExchangeRateCell")
+        tableView.backgroundColor = UIColor(named: "BackgroundColor") ?? .systemBackground
         return tableView
     }()
     
@@ -41,6 +44,7 @@ class ExchangeRateView: UIView {
     /// 코드 기반 초기화 메서드입니다. UI 구성 메서드를 호출합니다.
     override init(frame: CGRect) {
         super.init(frame: frame)
+        backgroundColor = UIColor(named: "BackgroundColor") ?? .systemBackground
         setUI()
     }
     

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
@@ -18,7 +18,7 @@ final class ExchangeRateViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "환율 정보"
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor(named: "BackgroundColor") ?? .systemBackground
 
         exchangeRateView.searchBar.delegate = self
         exchangeRateView.tableView.dataSource = self


### PR DESCRIPTION
## ✨ 기능 추가 PR

### 📌 관련 이슈
- close #21 

---

### 📌 변경 사항 및 이유
- 다크모드 환경에서도 사용자에게 일관되고 자연스러운 UI 제공을 위해 Asset Catalog 기반 색상 테마를 적용했습니다.
- 배경, 텍스트, 버튼 등 주요 UI 요소에 다크/라이트 모드별 색상이 자동으로 전환되도록 구현했습니다.
- `UIColor(named:)`를 활용해 Asset의 Any/Dark 설정을 참조합니다.
- 일부 시스템 색상 (`.label`, `.systemBackground`)도 fallback용으로 사용하였습니다.

---

### 📌 적용된 컴포넌트
- **ExchangeRateViewController**
  - `.view.backgroundColor → BackgroundColor`
- **ExchangeRateView**
  - `UITableView.backgroundColor → BackgroundColor`
  - `UISearchBar.searchTextField → CellBackgroundColor, TextColor`
- **ExchangeRateCell**
  - `.contentView.backgroundColor → CellBackgroundColor`
  - `UILabel들 → TextColor / SecondaryTextColor`
  - `즐겨찾기 버튼.tintColor → FavoriteColor`
- **CalculatorView**
  - `전체 뷰 배경 → BackgroundColor`
  - `UILabel들 → TextColor / SecondaryTextColor`
  - `UITextField → TextColor`
  - `UIButton.backgroundColor → ButtonColor`

---

### 📌 PR Point
- Asset Catalog의 Any/Dark 설정이 잘 적용되었는지
- 시스템 색상과 사용자 정의 색상의 fallback 처리 방식
- 각 뷰의 색상 적용 위치가 적절한지

---

### 📌 참고 사항
- 실제 다크모드 테스트는 Xcode 시뮬레이터에서 Appearance 전환 (`⌘ + Shift + A`) 또는 디바이스 설정에서 가능합니다.
- Asset Catalog에 등록된 색상은 `.colorset` 단위로 프로젝트에 포함되어 있습니다.
