### PR TITLE
Feat/#23

### DIFF
--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/App/SceneDelegate.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/App/SceneDelegate.swift
@@ -13,19 +13,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
+
         let window = UIWindow(windowScene: windowScene)
+
         let rootVC = ExchangeRateViewController()
-        let navVC = UINavigationController(rootViewController: rootVC)
-        
-        window.rootViewController = navVC
+        let navController = UINavigationController(rootViewController: rootVC)
+        window.rootViewController = navController
         self.window = window
         window.makeKeyAndVisible()
     }
+
+
 
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/CoreDataManager.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/CoreDataManager.swift
@@ -80,4 +80,30 @@ final class CoreDataManager {
         request.predicate = NSPredicate(format: "code == %@", code)
         return (try? context.fetch(request))?.first
     }
+    
+    // 저장
+    func saveAppState(screen: String, code: String?) {
+        // 항상 하나만 유지되도록 삭제 후 삽입 방식
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "AppState")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        _ = try? context.execute(deleteRequest)
+
+        let state = AppState(context: context)
+        state.lastScreen = screen
+        state.lastCurrencyCode = code
+        try? context.save()
+    }
+
+    // 조회
+    func getAppState() -> (screen: String, code: String?)? {
+        let request: NSFetchRequest<AppState> = AppState.fetchRequest()
+        guard let result = try? context.fetch(request),
+              let state = result.first,
+              let screen = state.lastScreen else {
+            return nil
+        }
+        return (screen: screen, code: state.lastCurrencyCode)
+    }
+
+
 }

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/CachedRateModel.xcdatamodeld/CachedRateModel.xcdatamodel/contents
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/Model/CachedRateModel.xcdatamodeld/CachedRateModel.xcdatamodel/contents
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="AppState" representedClassName="AppState" syncable="YES" codeGenerationType="class">
+        <attribute name="lastCurrencyCode" optional="YES" attributeType="String"/>
+        <attribute name="lastScreen" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="CachedRate" representedClassName=".CachedRate" syncable="YES">
         <attribute name="code" optional="YES" attributeType="String"/>
         <attribute name="previousRate" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/CalculatorViewController.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/CalculatorViewController.swift
@@ -18,7 +18,15 @@ class CalculatorViewController: UIViewController {
     override func loadView() {
         self.view = calculatorView
     }
+
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        CoreDataManager.shared.saveAppState(screen: "calculator", code: currencyCode)
+    }
     
+
+
     init(currencyCode: String, rate: Double) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = CalculatorViewModel(currencyCode: currencyCode, rate: rate)

--- a/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
+++ b/YWSCurrencyCalculator/YWSCurrencyCalculator/ViewController/ExchangeRateViewController.swift
@@ -10,11 +10,38 @@ import UIKit
 final class ExchangeRateViewController: UIViewController {
     private let exchangeRateView = ExchangeRateView()
     private let viewModel = ExchangeRateViewModel()
+    
+    private var hasPushedSavedScreen = false
 
     override func loadView() {
         view = exchangeRateView
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // 딱 한 번만 push
+        guard !hasPushedSavedScreen else { return }
+        hasPushedSavedScreen = true
+        
+        if let state = CoreDataManager.shared.getAppState(),
+           state.screen == "calculator",
+           let code = state.code,
+           let rate = CoreDataManager.shared.getCachedRate(for: code) {
+            
+            let vc = CalculatorViewController(currencyCode: code, rate: rate)
+            navigationController?.pushViewController(vc, animated: false)
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 뒤로 돌아왔을 때 상태를 "list"로 업데이트
+        CoreDataManager.shared.saveAppState(screen: "list", code: nil)
+    }
 
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "환율 정보"


### PR DESCRIPTION
## ✨ 기능 추가 PR

## 📌 관련 이슈
- close #23 

## 📌 변경 사항 및 이유
- 앱이 종료되었을 때 사용자가 마지막으로 본 화면(환율 리스트 or 계산기 화면)을 CoreData에 저장합니다.
- 앱을 재실행하면 마지막 상태를 복원하여 자동으로 해당 화면으로 이동합니다.
- 사용자가 계산기 화면을 보고 있었다면, 해당 통화의 계산기 화면으로 push됩니다.
- 입력값이나 결과값은 복원되지 않으며, 환율은 CoreData에 저장된 값을 사용합니다.

## 📌 PR Point
- SceneDelegate에서 항상 ExchangeRateViewController를 루트로 세팅한 후, 필요시 CalculatorViewController를 push하는 구조로 변경
- Calculator → 뒤로가기 → 리스트로 돌아올 때 AppState도 `"list"`로 갱신
- push가 중복되지 않도록 viewDidAppear에서 `hasPushedSavedScreen` 플래그로 제어

## 📌 참고 사항
- CoreData에 AppState 엔티티를 새로 추가하였습니다
- `CoreDataManager`에 상태 저장 및 조회용 메서드(`saveAppState`, `getAppState`) 추가
- SceneDelegate 및 CalculatorViewController, ExchangeRateViewController에 상태 저장 관련 로직 반영

